### PR TITLE
chore: refactor get airport endpoint and add search airport endpoint

### DIFF
--- a/extension_service/app/app_test.py
+++ b/extension_service/app/app_test.py
@@ -66,7 +66,7 @@ def test_hello_world(app):
         pytest.param({"iata": "sfo"}, id="iata_only"),
     ],
 )
-def test_get_airport_by_id(app, params):
+def test_get_airport(app, params):
     with TestClient(app) as client:
         response = client.get(
             "/airports",
@@ -94,7 +94,7 @@ def test_get_airport_by_id(app, params):
         pytest.param({"name": "san francisco"}, id="name_only"),
     ],
 )
-def test_search_airports(app, params, expected):
+def test_search_airports(app, params):
     with TestClient(app) as client:
         response = client.get(
             "/airports/search",
@@ -103,7 +103,7 @@ def test_search_airports(app, params, expected):
     assert response.status_code == 200
     output = response.json()
     assert output
-    assert models.Airport.model_validate(output)
+    assert models.Airport.model_validate(output[0])
 
 
 @pytest.mark.parametrize(

--- a/extension_service/app/app_test.py
+++ b/extension_service/app/app_test.py
@@ -82,54 +82,29 @@ def test_get_airport_by_iata(app):
     assert output[0]
 
 
-def test_search_airports(app):
-    with TestClient(app) as client:
-        response = client.get(
-            "/airports/search",
-            params={
-                "city": "san francisco",
+@pytest.mark.parametrize(
+    "params, expected",
+    [
+        pytest.param(
+            {
                 "country": "United States",
+                "city": "san francisco",
                 "name": "san francisco",
             },
-        )
-    assert response.status_code == 200
-    output = response.json()
-    assert output[0]
-
-
-def test_search_airports_by_country_only(app):
+            "foobar",
+            id="country_city_and_name",
+        ),
+        pytest.param({"country": "United States"}, "foobar", id="country_only"),
+        pytest.param({"city": "san francisco"}, "foobar", id="city_only"),
+        pytest.param({"name": "san francisco"}, "foobar", id="name_only"),
+        pytest.param({}, "foobar", id="no_params"),
+    ],
+)
+def test_search_airports(app, params, expected):
     with TestClient(app) as client:
         response = client.get(
             "/airports/search",
-            params={
-                "country": "United States",
-            },
-        )
-    assert response.status_code == 200
-    output = response.json()
-    assert output[0]
-
-
-def test_search_airports_by_city_only(app):
-    with TestClient(app) as client:
-        response = client.get(
-            "/airports/search",
-            params={
-                "city": "san francisco",
-            },
-        )
-    assert response.status_code == 200
-    output = response.json()
-    assert output[0]
-
-
-def test_search_airports_by_name_only(app):
-    with TestClient(app) as client:
-        response = client.get(
-            "/airports/search",
-            params={
-                "name": "san francisco",
-            },
+            params=params,
         )
     assert response.status_code == 200
     output = response.json()

--- a/extension_service/app/app_test.py
+++ b/extension_service/app/app_test.py
@@ -54,7 +54,7 @@ def test_hello_world(app):
         assert response.json() == {"message": "Hello World"}
 
 
-def test_get_airport(app):
+def test_get_airport_by_id(app):
     with TestClient(app) as client:
         response = client.get(
             "/airports",
@@ -66,6 +66,74 @@ def test_get_airport(app):
     output = response.json()
     assert output
     assert models.Airport.model_validate(output)
+
+
+def test_get_airport_by_iata(app):
+    with TestClient(app) as client:
+        response = client.get(
+            "/airports",
+            params={
+                "iata": "sfo",
+            },
+        )
+    assert response.status_code == 200
+    output = response.json()
+    assert len(output) == 1
+    assert output[0]
+
+
+def test_search_airports(app):
+    with TestClient(app) as client:
+        response = client.get(
+            "/airports/search",
+            params={
+                "city": "san francisco",
+                "country": "United States",
+                "name": "san francisco",
+            },
+        )
+    assert response.status_code == 200
+    output = response.json()
+    assert output[0]
+
+
+def test_search_airports_by_country_only(app):
+    with TestClient(app) as client:
+        response = client.get(
+            "/airports/search",
+            params={
+                "country": "United States",
+            },
+        )
+    assert response.status_code == 200
+    output = response.json()
+    assert output[0]
+
+
+def test_search_airports_by_city_only(app):
+    with TestClient(app) as client:
+        response = client.get(
+            "/airports/search",
+            params={
+                "city": "san francisco",
+            },
+        )
+    assert response.status_code == 200
+    output = response.json()
+    assert output[0]
+
+
+def test_search_airports_by_name_only(app):
+    with TestClient(app) as client:
+        response = client.get(
+            "/airports/search",
+            params={
+                "name": "san francisco",
+            },
+        )
+    assert response.status_code == 200
+    output = response.json()
+    assert output[0]
 
 
 def test_get_amenity(app):

--- a/extension_service/app/routes.py
+++ b/extension_service/app/routes.py
@@ -29,9 +29,28 @@ async def root():
 
 
 @routes.get("/airports")
-async def get_airport(id: int, request: Request):
+async def get_airport(
+    request: Request,
+    id: Optional[int] = None,
+    iata: Optional[str] = None,
+):
     ds: datastore.Client = request.app.state.datastore
-    results = await ds.get_airport(id)
+    if id:
+        results = await ds.get_airport_by_id(id)
+    elif iata:
+        results = await ds.get_airport_by_iata(iata)
+    return results
+
+
+@routes.get("/airports/search")
+async def search_airports(
+    request: Request,
+    country: Optional[str] = None,
+    city: Optional[str] = None,
+    name: Optional[str] = None,
+):
+    ds: datastore.Client = request.app.state.datastore
+    results = await ds.search_airports(country, city, name)
     return results
 
 

--- a/extension_service/app/routes.py
+++ b/extension_service/app/routes.py
@@ -39,6 +39,11 @@ async def get_airport(
         results = await ds.get_airport_by_id(id)
     elif iata:
         results = await ds.get_airport_by_iata(iata)
+    else:
+        raise HTTPException(
+            status_code=422,
+            detail="Request requires query params: airport id or iata",
+        )
     return results
 
 
@@ -49,6 +54,12 @@ async def search_airports(
     city: Optional[str] = None,
     name: Optional[str] = None,
 ):
+    if country == None and city == None and name == None:
+        raise HTTPException(
+            status_code=422,
+            detail="Request requires at least one query params: country, city, or airport name",
+        )
+
     ds: datastore.Client = request.app.state.datastore
     results = await ds.search_airports(country, city, name)
     return results

--- a/extension_service/datastore/datastore.py
+++ b/extension_service/datastore/datastore.py
@@ -60,7 +60,20 @@ class Client(ABC, Generic[C]):
         pass
 
     @abstractmethod
-    async def get_airport(self, id: int) -> Optional[models.Airport]:
+    async def get_airport_by_id(self, id: int) -> Optional[models.Airport]:
+        raise NotImplementedError("Subclass should implement this!")
+
+    @abstractmethod
+    async def get_airport_by_iata(self, iata: str) -> Optional[models.Airport]:
+        raise NotImplementedError("Subclass should implement this!")
+
+    @abstractmethod
+    async def search_airports(
+        self,
+        country: Optional[str] = None,
+        city: Optional[str] = None,
+        name: Optional[str] = None,
+    ) -> Optional[list[models.Airport]]:
         raise NotImplementedError("Subclass should implement this!")
 
     @abstractmethod

--- a/extension_service/datastore/datastore.py
+++ b/extension_service/datastore/datastore.py
@@ -73,7 +73,7 @@ class Client(ABC, Generic[C]):
         country: Optional[str] = None,
         city: Optional[str] = None,
         name: Optional[str] = None,
-    ) -> Optional[list[models.Airport]]:
+    ) -> list[models.Airport]:
         raise NotImplementedError("Subclass should implement this!")
 
     @abstractmethod
@@ -83,7 +83,7 @@ class Client(ABC, Generic[C]):
     @abstractmethod
     async def amenities_search(
         self, query_embedding: list[float], similarity_threshold: float, top_k: int
-    ) -> Optional[list[models.Amenity]]:
+    ) -> list[models.Amenity]:
         raise NotImplementedError("Subclass should implement this!")
 
     @abstractmethod

--- a/extension_service/datastore/providers/postgres.py
+++ b/extension_service/datastore/providers/postgres.py
@@ -219,18 +219,12 @@ class Client(datastore.Client[Config]):
         city: Optional[str] = None,
         name: Optional[str] = None,
     ) -> list[models.Airport]:
-        if country is None:
-            country = "%"
-        if city is None:
-            city = "%"
-        name = "%" if name is None else f"%{name}%"
-
         results = await self.__pool.fetch(
             """
             SELECT * FROM airports
-            WHERE (country IS NULL OR country ILIKE $1)
-            AND (city IS NULL OR city ILIKE $2)
-            AND (name IS NULL OR name ILIKE $3)
+            WHERE ($1::TEXT IS NULL OR country ILIKE $1)
+            AND ($2::TEXT IS NULL OR city ILIKE $2)
+            AND ($3::TEXT IS NULL OR name ILIKE '%' || $3 || '%')
             """,
             country,
             city,

--- a/extension_service/datastore/providers/postgres.py
+++ b/extension_service/datastore/providers/postgres.py
@@ -185,10 +185,10 @@ class Client(datastore.Client[Config]):
         flights = [models.Flight.model_validate(dict(f)) for f in await flights_task]
         return airports, amenities, flights
 
-    async def get_airport(self, id: int) -> Optional[models.Airport]:
+    async def get_airport_by_id(self, id: int) -> Optional[models.Airport]:
         result = await self.__pool.fetchrow(
             """
-              SELECT id, iata, name, city, country FROM airports WHERE id=$1
+              SELECT * FROM airports WHERE id=$1
             """,
             id,
         )
@@ -198,6 +198,52 @@ class Client(datastore.Client[Config]):
 
         result = models.Airport.model_validate(dict(result))
         return result
+
+    async def get_airport_by_iata(self, iata: str) -> Optional[models.Airport]:
+        result = await self.__pool.fetchrow(
+            """
+              SELECT * FROM airports WHERE iata ILIKE $1
+            """,
+            iata,
+        )
+
+        if result is None:
+            return None
+
+        result = models.Airport.model_validate(dict(result))
+        return result
+
+    async def search_airports(
+        self,
+        country: Optional[str] = None,
+        city: Optional[str] = None,
+        name: Optional[str] = None,
+    ) -> Optional[list[models.Airport]]:
+        if country is None:
+            country = "%"
+        if city is None:
+            city = "%"
+        name = "%" if name is None else "%" + name + "%"
+
+        results = await self.__pool.fetch(
+            """
+            SELECT * FROM (
+                SELECT * FROM (
+                    SELECT * FROM airports
+                    WHERE country ILIKE $1
+                ) AS filtered_country
+                WHERE city ILIKE $2
+            ) AS filtered_city
+            WHERE name ILIKE $3
+            """,
+            country,
+            city,
+            name,
+            timeout=10,
+        )
+
+        results = [models.Airport.model_validate(dict(r)) for r in results]
+        return results
 
     async def get_amenity(self, id: int) -> Optional[models.Amenity]:
         result = await self.__pool.fetchrow(

--- a/extension_service/datastore/providers/postgres_test.py
+++ b/extension_service/datastore/providers/postgres_test.py
@@ -65,10 +65,10 @@ async def test_get_airport():
             ("country", "bundy"),
         ]
     )
-    query = "SELECT id, iata, name, city, country FROM airports WHERE id=$1"
+    query = "SELECT * FROM airports WHERE id=$1"
     mocks = {query: mockRecord}
     mockCl = await mock_postgres_provider(mocks)
-    res = await mockCl.get_airport(id=1)
+    res = await mockCl.get_airport_by_id(1)
     expected_res = models.Airport(
         id=1,
         iata="FOO",

--- a/extension_service/datastore/providers/postgres_test.py
+++ b/extension_service/datastore/providers/postgres_test.py
@@ -68,7 +68,7 @@ async def test_get_airport():
     query = "SELECT id, iata, name, city, country FROM airports WHERE id=$1"
     mocks = {query: mockRecord}
     mockCl = await mock_postgres_provider(mocks)
-    res = await mockCl.get_airport(1)
+    res = await mockCl.get_airport(id=1)
     expected_res = models.Airport(
         id=1,
         iata="FOO",


### PR DESCRIPTION
Refactor get airport endpoint to include iata as param. 
Add search airports endpoint with city and/or country and/or name as param.

Did not add unit test for the providers now, will work on tests when add integration test in future PR.