### PR TITLE
chore: parametrize flights search app_test and update search return

### DIFF
--- a/extension_service/app/app_test.py
+++ b/extension_service/app/app_test.py
@@ -119,34 +119,23 @@ def test_get_flight(app):
     assert output[0]
 
 
-def test_search_flights_by_airport(app):
+@pytest.mark.parametrize(
+    "params, expected",
+    [
+        pytest.param(
+            {"departure_airport": "LAX", "arrival_airport": "SFO"},
+            "foobar",
+            id="departure_and_arrival_airport",
+        ),
+        pytest.param({"arrival_airport": "SFO"}, "foobar", id="arrival_airport_only"),
+        pytest.param(
+            {"departure_airport": "EWR"}, "foobar", id="departure_airport_only"
+        ),
+    ],
+)
+def test_search_flights(app, params, expected):
     with TestClient(app) as client:
-        response = client.get(
-            "/flights/search",
-            params={"departure_airport": "LAX", "arrival_airport": "SFO"},
-        )
-    assert response.status_code == 200
-    output = response.json()
-    assert output[0]
-
-
-def test_search_flights_by_airport_arrival_only(app):
-    with TestClient(app) as client:
-        response = client.get(
-            "/flights/search",
-            params={"arrival_airport": "SFO"},
-        )
-    assert response.status_code == 200
-    output = response.json()
-    assert output[0]
-
-
-def test_search_flights_by_airport_departure_only(app):
-    with TestClient(app) as client:
-        response = client.get(
-            "/flights/search",
-            params={"departure_airport": "EWR"},
-        )
+        response = client.get("/flights/search", params=params)
     assert response.status_code == 200
     output = response.json()
     assert output[0]

--- a/extension_service/datastore/datastore.py
+++ b/extension_service/datastore/datastore.py
@@ -74,7 +74,7 @@ class Client(ABC, Generic[C]):
         raise NotImplementedError("Subclass should implement this!")
 
     @abstractmethod
-    async def get_flight(self, flight_id: int) -> Optional[list[models.Flight]]:
+    async def get_flight(self, flight_id: int) -> Optional[models.Flight]:
         raise NotImplementedError("Subclass should implement this!")
 
     @abstractmethod
@@ -82,7 +82,7 @@ class Client(ABC, Generic[C]):
         self,
         airline: str,
         flight_number: str,
-    ) -> Optional[list[models.Flight]]:
+    ) -> list[models.Flight]:
         raise NotImplementedError("Subclass should implement this!")
 
     @abstractmethod
@@ -91,7 +91,7 @@ class Client(ABC, Generic[C]):
         date,
         departure_airport: Optional[str] = None,
         arrival_airport: Optional[str] = None,
-    ) -> Optional[list[models.Flight]]:
+    ) -> list[models.Flight]:
         raise NotImplementedError("Subclass should implement this!")
 
     @abstractmethod


### PR DESCRIPTION
Flight search app_test is not yet fully tested (flight num and airlines are not tested yet). Just update the function to use parametrize testing. 

Keep endpoint functions consistent (airport and amenities are getting updated in another PR):
Remove Optional from flight search function since it is returning empty list.
Update flight get function to use fetchrow and return None when nothing is returned.