### PR TITLE
ci: add trusted contribution bot

### DIFF
--- a/.github/trusted-contribution.yml
+++ b/.github/trusted-contribution.yml
@@ -1,0 +1,5 @@
+annotations:
+  - type: comment
+    text: "/gcbrun"
+trustedContributors:
+  - renovate-bot


### PR DESCRIPTION
Adds comment `/gcbrun` to renovate bot PRs in order to trigger tests