### PR TITLE
fix: update alloydb.md to remove extra trailing space

### DIFF
--- a/docs/datastore/alloydb.md
+++ b/docs/datastore/alloydb.md
@@ -23,7 +23,7 @@
     ```bash
     gcloud services enable alloydb.googleapis.com \
                            compute.googleapis.com \
-                           cloudresourcemanager.googleapis.com \ 
+                           cloudresourcemanager.googleapis.com \
                            servicenetworking.googleapis.com \
                            vpcaccess.googleapis.com \
                            aiplatform.googleapis.com


### PR DESCRIPTION
extra space was breaking copy/paste