### PR TITLE
Update alloydb.md fix git clone URL

### DIFF
--- a/docs/datastore/alloydb.md
+++ b/docs/datastore/alloydb.md
@@ -35,7 +35,7 @@
 1. Clone this repo to your local machine:
 
     ```bash
-        git clone git@github.com:GoogleCloudPlatform/database-query-extension.git
+    git clone https://github.com/GoogleCloudPlatform/database-query-extension.git
     ```
 
 


### PR DESCRIPTION
previous URL didn't work for git clone operation (permission denied)