### PR TITLE
chore: turn off renovate rebase

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,7 +9,7 @@
     ":semanticPrefixFixDepsChoreOthers"
   ],
   "prConcurrentLimit": 0,
-  "rebaseWhen": "behind-base-branch",
+  "rebaseWhen": "never",
   "dependencyDashboard": true,
   "dependencyDashboardLabels": [
     "type: process"


### PR DESCRIPTION
Renovate rebases on every merge into main. To reduce the churn on multiple dependency updates, we can manually rebase/update the branch.