### PR TITLE
feat(docs): update gcloud track for deployment with VPC network 

### DIFF
--- a/docs/deploy_extension_service.md
+++ b/docs/deploy_extension_service.md
@@ -82,7 +82,15 @@ datastore:
             --no-allow-unauthenticated \
             --service-account extension-identity \
             --region us-central1 \
-            # The follow flags are optional if you aren't using a VPC 
+        ```
+
+        If you are using a VPC network, use the command below:
+        ```bash
+        gcloud alpha run deploy extension-service \
+            --source=./extension_service/\
+            --no-allow-unauthenticated \
+            --service-account extension-identity \
+            --region us-central1 \
             --network=default \ 
             --subnet=default
         ```


### PR DESCRIPTION
Currently the VPC network flags `--network` and `--subnet` are only available on the gcloud alpha track according to: https://cloud.google.com/sdk/gcloud/reference/alpha/run/deploy and https://cloud.google.com/sdk/gcloud/reference/run/deploy.
Update cloud run deployment instruction to reflect this.