### PR TITLE
chore: group aynscpg and asyncpg-stubs for renovate updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -22,7 +22,7 @@
   },
   "packageRules": [
     {
-      "groupName": "ayncpg",
+      "groupName": "asyncpg",
       "matchPackageNames": [
         "asyncpg",
         "asyncpg-stubs"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -19,5 +19,14 @@
     "fileMatch": [
       "requirements-test.txt"
     ]
-  }
+  },
+  "packageRules": [
+    {
+      "groupName": "ayncpg",
+      "matchPackageNames": [
+        "asyncpg",
+        "asyncpg-stubs"
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
Update aynscpg and asyncpg-stubs together to fix the conflicting dependency error raised by renovate update.